### PR TITLE
Fix security issue for external link

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <p>This site is dedicated to the publication and access of Igor Vepretski’s interdisciplinary monograph, exploring media, civic trust, and digital influence in the modern age.</p>
 
     <p>Full downloadable version will be available soon. For now, you can access the GitHub repository with full source and materials here:</p>
-    <p><a href="https://github.com/vepretski/power-media-modern-identity" target="_blank">GitHub Repository</a></p>
+    <p><a href="https://github.com/vepretski/power-media-modern-identity" target="_blank" rel="noopener noreferrer">GitHub Repository</a></p>
 
     <div class="footer">
       © 2025 Igor Vepretski. Powered by GitHub Pages.


### PR DESCRIPTION
## Summary
- mitigate potential tabnabbing by adding `rel="noopener noreferrer"` to the external GitHub link in `index.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669011cee48327a6133ab0809e1d59