### PR TITLE
Fix broken EPUB link and improve README

### DIFF
--- a/GoogleScholar_Landing_IgorVepretski.html
+++ b/GoogleScholar_Landing_IgorVepretski.html
@@ -9,7 +9,7 @@
     <meta name="citation_publication_place" content="Tel Aviv">
     <meta name="citation_publisher" content="Self-Published via Kindle Direct Publishing">
     <meta name="citation_language" content="en">
-    <meta name="citation_pdf_url" content="https://linktr.ee/igor.vepretski">
+    <meta name="citation_pdf_url" content="Complete_Book_Igor_Vepretski.pdf">
     <meta name="citation_abstract" content="This monograph explores the convergence of media theory, intelligence work, and digital civic leadership through the interdisciplinary career of Igor Vepretski. It introduces the 'Vepretski Model'—a framework for ethical influence and hybrid trust-building in algorithmic societies.">
 </head>
 <body>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# power-media-modern-identity
+# Power, Media, and Modern Identity
+
+For full documentation, including downloads and citation information, see [README_Power_Media_IgorVepretski.md](README_Power_Media_IgorVepretski.md).

--- a/README_Power_Media_IgorVepretski.md
+++ b/README_Power_Media_IgorVepretski.md
@@ -12,7 +12,7 @@ It spans media framing, digital virality, public trust, surveillance ethics, and
 
 - [Full Book – PDF](Complete_Book_Igor_Vepretski.pdf)
 - [Word Document](Complete_Book_Igor_Vepretski.docx)
-- [Kindle/EPUB Version](Complete_Book_Igor_Vepretski.epub)
+- Kindle/EPUB Version (coming soon)
 - [Press Kit](Igor_Vepretski_Press_Kit.pdf)
 - [BibTeX Citation](Vepretski_Book_Citation.bib)
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <p>This site is dedicated to the publication and access of Igor Vepretski’s interdisciplinary monograph, exploring media, civic trust, and digital influence in the modern age.</p>
 
     <p>Full downloadable version will be available soon. For now, you can access the GitHub repository with full source and materials here:</p>
-    <p><a href="https://github.com/vepretski/power-media-modern-identity" target="_blank">GitHub Repository</a></p>
+    <p><a href="https://github.com/vepretski/power-media-modern-identity" target="_blank" rel="noopener noreferrer">GitHub Repository</a></p>
 
     <div class="footer">
       © 2025 Igor Vepretski. Powered by GitHub Pages.


### PR DESCRIPTION
## Summary
- link to future Kindle/EPUB version instead of a missing file
- add root README that points to the detailed documentation
- point Google Scholar metadata to the included PDF

## Testing
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68669011cee48327a6133ab0809e1d59